### PR TITLE
Add CSV export for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Once the backend is running, visit http://localhost:8000/docs for interactive Sw
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | /api/products | List products (search, category, low_stock filter) |
+| GET | /api/products/export | Download filtered products as CSV |
 | POST | /api/products | Create product |
 | PUT | /api/products/{id} | Update product |
 | DELETE | /api/products/{id} | Delete product (only if stock is 0) |

--- a/backend/agents/export_service.py
+++ b/backend/agents/export_service.py
@@ -1,0 +1,47 @@
+"""CSV export service for products."""
+
+import csv
+import io
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from agents import product_service
+
+
+CSV_COLUMNS = [
+    "sku",
+    "name",
+    "category",
+    "supplier_name",
+    "unit_price",
+    "current_stock",
+    "reorder_level",
+]
+
+
+def export_products_to_csv(
+    db: Session,
+    search: Optional[str] = None,
+    category: Optional[str] = None,
+    low_stock_only: bool = False,
+) -> str:
+    """Return a CSV string of products matching the given filters."""
+    products = product_service.list_products(db, search, category, low_stock_only)
+
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+
+    for product in products:
+        writer.writerow({
+            "sku": product.sku,
+            "name": product.name,
+            "category": product.category,
+            "supplier_name": product.supplier.name if product.supplier else "",
+            "unit_price": f"{product.unit_price:.2f}",
+            "current_stock": product.current_stock,
+            "reorder_level": product.reorder_level,
+        })
+
+    return buffer.getvalue()

--- a/backend/agents/routes.py
+++ b/backend/agents/routes.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, UploadFile, File, HTTPException
+from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
 from db.database import get_db
@@ -17,6 +18,7 @@ from models.schemas import (
 )
 from agents import product_service, movement_service, supplier_service, analytics_service
 from agents.import_service import import_products_from_csv, MAX_FILE_SIZE
+from agents.export_service import export_products_to_csv
 from agents.auth_deps import get_current_user, require_role
 from models.orm import User
 
@@ -89,6 +91,22 @@ def list_products(
 ):
     products = product_service.list_products(db, search, category, low_stock)
     return [_product_response(p) for p in products]
+
+
+@product_router.get("/export")
+def export_products(
+    search: Optional[str] = Query(None),
+    category: Optional[str] = Query(None),
+    low_stock: bool = Query(False),
+    db: Session = Depends(get_db),
+    _user: User = Depends(get_current_user),
+):
+    csv_content = export_products_to_csv(db, search, category, low_stock)
+    return Response(
+        content=csv_content,
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="products.csv"'},
+    )
 
 
 @product_router.get("/{product_id}", response_model=ProductResponse)

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,0 +1,92 @@
+"""Tests for product CSV export endpoint."""
+
+import csv
+import io
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+class TestExportProducts:
+    """GET /api/products/export"""
+
+    def _parse_csv(self, body: str) -> list[dict]:
+        reader = csv.DictReader(io.StringIO(body))
+        return list(reader)
+
+    def test_returns_csv_response(self, client, seed_data):
+        resp = client.get("/api/products/export")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/csv")
+        assert "attachment" in resp.headers["content-disposition"]
+        assert "products.csv" in resp.headers["content-disposition"]
+
+    def test_csv_contains_all_products(self, client, seed_data):
+        resp = client.get("/api/products/export")
+        rows = self._parse_csv(resp.text)
+        assert len(rows) == 5
+
+    def test_csv_has_expected_columns(self, client, seed_data):
+        resp = client.get("/api/products/export")
+        rows = self._parse_csv(resp.text)
+        expected = {
+            "sku",
+            "name",
+            "category",
+            "supplier_name",
+            "unit_price",
+            "current_stock",
+            "reorder_level",
+        }
+        assert set(rows[0].keys()) == expected
+
+    def test_csv_rows_include_supplier_name(self, client, seed_data):
+        resp = client.get("/api/products/export")
+        rows = self._parse_csv(resp.text)
+        # All seed products have suppliers
+        assert all(row["supplier_name"] for row in rows)
+
+    def test_filter_by_category(self, client, seed_data):
+        resp = client.get("/api/products/export", params={"category": "Elektronik"})
+        rows = self._parse_csv(resp.text)
+        assert len(rows) == 1
+        assert rows[0]["category"] == "Elektronik"
+
+    def test_filter_by_search(self, client, seed_data):
+        resp = client.get("/api/products/export", params={"search": "Laptop"})
+        rows = self._parse_csv(resp.text)
+        assert len(rows) == 1
+        assert rows[0]["name"] == "Laptop Pro 15"
+
+    def test_filter_low_stock(self, client, seed_data):
+        resp = client.get("/api/products/export", params={"low_stock": "true"})
+        rows = self._parse_csv(resp.text)
+        # Same low-stock items as the list endpoint
+        for row in rows:
+            assert int(row["current_stock"]) <= int(row["reorder_level"])
+
+    def test_empty_result_returns_header_only(self, client, seed_data):
+        resp = client.get(
+            "/api/products/export", params={"search": "no-such-product"}
+        )
+        assert resp.status_code == 200
+        rows = self._parse_csv(resp.text)
+        assert rows == []
+        # Header row still present
+        assert "sku" in resp.text.splitlines()[0]
+
+    def test_unauthenticated_request_rejected(self, db_session):
+        """Export must require a valid token."""
+        from db.database import get_db
+
+        def _override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = _override_get_db
+        try:
+            with TestClient(app) as tc:
+                resp = tc.get("/api/products/export")
+                assert resp.status_code == 401
+        finally:
+            app.dependency_overrides.clear()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -101,6 +101,31 @@ export interface ImportResult {
   errors: { row: number; error: string }[];
 }
 
+export async function exportProductsCsv(params?: {
+  search?: string;
+  category?: string;
+  low_stock?: boolean;
+}): Promise<Blob> {
+  const query = new URLSearchParams();
+  if (params?.search) query.set("search", params.search);
+  if (params?.category) query.set("category", params.category);
+  if (params?.low_stock) query.set("low_stock", "true");
+  const qs = query.toString();
+  const token = localStorage.getItem("token");
+  const headers: Record<string, string> = {};
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const res = await fetch(`/api/products/export${qs ? `?${qs}` : ""}`, {
+    headers,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new ApiError(body || res.statusText, res.status);
+  }
+  return res.blob();
+}
+
 export async function importProductsCsv(file: File): Promise<ImportResult> {
   const formData = new FormData();
   formData.append("file", file);

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { Pencil, Trash2, Plus, Search, Upload } from "lucide-react";
+import { Pencil, Trash2, Plus, Search, Upload, Download } from "lucide-react";
 import {
   fetchProducts,
   fetchSuppliers,
@@ -7,6 +7,7 @@ import {
   updateProduct,
   deleteProduct,
   importProductsCsv,
+  exportProductsCsv,
 } from "../api/client";
 import type { Product, ProductCreate, Supplier } from "../types";
 import Modal from "../components/Modal";
@@ -46,6 +47,8 @@ export default function Products() {
 
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [deleting, setDeleting] = useState(false);
+
+  const [exporting, setExporting] = useState(false);
 
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -129,6 +132,29 @@ export default function Products() {
     }
   }
 
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const blob = await exportProductsCsv({
+        search: search || undefined,
+        category: categoryFilter || undefined,
+        low_stock: lowStockOnly || undefined,
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "products.csv";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
+
   async function handleImport() {
     const file = fileInputRef.current?.files?.[0];
     if (!file) return;
@@ -150,6 +176,14 @@ export default function Products() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-gray-900">Products</h1>
         <div className="flex items-center gap-3">
+          <button
+            onClick={handleExport}
+            disabled={exporting}
+            className="flex items-center gap-2 border border-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-50 text-sm font-medium disabled:opacity-50"
+          >
+            <Download className="w-4 h-4" />
+            {exporting ? "Exporting..." : "Export CSV"}
+          </button>
           <button
             onClick={() => {
               setImportResult(null);


### PR DESCRIPTION
## Summary

- New backend endpoint `GET /api/products/export` returns a CSV file with the active filters (`search`, `category`, `low_stock`)
- Frontend gets an **Export CSV** button next to the existing Import button on the Products page
- 9 new backend tests covering response headers, filters, empty results, and auth

Closes #22

## Test plan

- [x] All 72 backend tests pass (`pytest -v`)
- [x] `tsc --noEmit` clean
- [ ] Manual: click Export CSV, file downloads with expected columns
- [ ] Manual: apply a category filter, click Export, only matching rows are in the CSV
