### PR TITLE
Add pagination and sortable columns to products list

### DIFF
--- a/backend/agents/product_service.py
+++ b/backend/agents/product_service.py
@@ -1,19 +1,27 @@
 from typing import Optional
 
 from fastapi import HTTPException
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from models.orm import Product
 from models.schemas import ProductCreate, ProductUpdate
 
 
-def list_products(
+SORTABLE_FIELDS = {
+    "name": Product.name,
+    "sku": Product.sku,
+    "category": Product.category,
+    "unit_price": Product.unit_price,
+    "current_stock": Product.current_stock,
+}
+
+
+def _filter_query(
     db: Session,
-    search: Optional[str] = None,
-    category: Optional[str] = None,
-    low_stock_only: bool = False,
-) -> list[Product]:
-    """Return products with optional filtering."""
+    search: Optional[str],
+    category: Optional[str],
+    low_stock_only: bool,
+) -> Query:
     query = db.query(Product)
 
     if search:
@@ -28,7 +36,39 @@ def list_products(
     if low_stock_only:
         query = query.filter(Product.current_stock <= Product.reorder_level)
 
-    return query.order_by(Product.name).all()
+    return query
+
+
+def list_products(
+    db: Session,
+    search: Optional[str] = None,
+    category: Optional[str] = None,
+    low_stock_only: bool = False,
+    sort_by: str = "name",
+    sort_dir: str = "asc",
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> list[Product]:
+    """Return products with optional filtering, sorting and pagination."""
+    query = _filter_query(db, search, category, low_stock_only)
+
+    column = SORTABLE_FIELDS[sort_by]
+    query = query.order_by(column.desc() if sort_dir == "desc" else column.asc())
+
+    if limit is not None:
+        query = query.limit(limit).offset(offset)
+
+    return query.all()
+
+
+def count_products(
+    db: Session,
+    search: Optional[str] = None,
+    category: Optional[str] = None,
+    low_stock_only: bool = False,
+) -> int:
+    """Count products matching the same filters as list_products."""
+    return _filter_query(db, search, category, low_stock_only).count()
 
 
 def get_product(db: Session, product_id: int) -> Product:

--- a/backend/agents/product_service.py
+++ b/backend/agents/product_service.py
@@ -3,17 +3,20 @@ from typing import Optional
 from fastapi import HTTPException
 from sqlalchemy.orm import Query, Session
 
-from models.orm import Product
+from models.orm import Product, Supplier
 from models.schemas import ProductCreate, ProductUpdate
 
 
-SORTABLE_FIELDS = {
+_DIRECT_SORTABLE = {
     "name": Product.name,
     "sku": Product.sku,
     "category": Product.category,
     "unit_price": Product.unit_price,
     "current_stock": Product.current_stock,
+    "reorder_level": Product.reorder_level,
 }
+
+SORTABLE_FIELDS = set(_DIRECT_SORTABLE) | {"supplier_name"}
 
 
 def _filter_query(
@@ -52,7 +55,11 @@ def list_products(
     """Return products with optional filtering, sorting and pagination."""
     query = _filter_query(db, search, category, low_stock_only)
 
-    column = SORTABLE_FIELDS[sort_by]
+    if sort_by == "supplier_name":
+        query = query.outerjoin(Supplier, Product.supplier_id == Supplier.id)
+        column = Supplier.name
+    else:
+        column = _DIRECT_SORTABLE[sort_by]
     query = query.order_by(column.desc() if sort_dir == "desc" else column.asc())
 
     if limit is not None:

--- a/backend/agents/routes.py
+++ b/backend/agents/routes.py
@@ -9,6 +9,7 @@ from models.schemas import (
     ProductCreate,
     ProductUpdate,
     ProductResponse,
+    PaginatedProductsResponse,
     MovementCreate,
     MovementResponse,
     SupplierCreate,
@@ -81,16 +82,39 @@ def _supplier_response(supplier) -> dict:
 # Product endpoints
 # ---------------------------------------------------------------------------
 
-@product_router.get("", response_model=list[ProductResponse])
+@product_router.get("", response_model=PaginatedProductsResponse)
 def list_products(
     search: Optional[str] = Query(None),
     category: Optional[str] = Query(None),
     low_stock: bool = Query(False),
+    sort_by: str = Query("name"),
+    sort_dir: str = Query("asc"),
+    limit: int = Query(25, ge=1, le=100),
+    offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
     _user: User = Depends(get_current_user),
 ):
-    products = product_service.list_products(db, search, category, low_stock)
-    return [_product_response(p) for p in products]
+    if sort_by not in product_service.SORTABLE_FIELDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid sort_by '{sort_by}'. Allowed: {sorted(product_service.SORTABLE_FIELDS)}",
+        )
+    if sort_dir not in {"asc", "desc"}:
+        raise HTTPException(
+            status_code=400,
+            detail="sort_dir must be 'asc' or 'desc'",
+        )
+
+    products = product_service.list_products(
+        db, search, category, low_stock, sort_by, sort_dir, limit, offset
+    )
+    total = product_service.count_products(db, search, category, low_stock)
+    return {
+        "items": [_product_response(p) for p in products],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @product_router.get("/export")

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -42,6 +42,13 @@ class ProductResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class PaginatedProductsResponse(BaseModel):
+    items: list[ProductResponse]
+    total: int
+    limit: int
+    offset: int
+
+
 # ---------------------------------------------------------------------------
 # Stock Movement
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_import.py
+++ b/backend/tests/test_import.py
@@ -107,9 +107,9 @@ class TestImportEndpoint:
         assert data["imported"] == 1
 
         # Verify the product was created with the supplier
-        products = client.get("/api/products", params={"search": "WS-001"}).json()
-        assert len(products) == 1
-        assert products[0]["supplier_id"] == supplier_id
+        data = client.get("/api/products", params={"search": "WS-001"}).json()
+        assert data["total"] == 1
+        assert data["items"][0]["supplier_id"] == supplier_id
 
     def test_missing_required_field_in_row(self, client, seed_data):
         csv = self._csv_bytes([
@@ -133,7 +133,7 @@ class TestImportEndpoint:
             "/api/products/import",
             files={"file": ("products.csv", io.BytesIO(csv), "text/csv")},
         )
-        products = client.get("/api/products", params={"search": "IMP-001"}).json()
-        assert len(products) == 1
-        assert products[0]["name"] == "Imported Product"
-        assert products[0]["current_stock"] == 0
+        data = client.get("/api/products", params={"search": "IMP-001"}).json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "Imported Product"
+        assert data["items"][0]["current_stock"] == 0

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -40,7 +40,7 @@ class TestPaginationAndSorting:
 
     @pytest.mark.parametrize(
         "field",
-        ["name", "sku", "category", "unit_price", "current_stock"],
+        ["name", "sku", "category", "unit_price", "current_stock", "reorder_level", "supplier_name"],
     )
     def test_sort_asc(self, client, seed_data, field):
         resp = client.get("/api/products", params={"sort_by": field, "sort_dir": "asc"})
@@ -50,7 +50,7 @@ class TestPaginationAndSorting:
 
     @pytest.mark.parametrize(
         "field",
-        ["name", "sku", "category", "unit_price", "current_stock"],
+        ["name", "sku", "category", "unit_price", "current_stock", "reorder_level", "supplier_name"],
     )
     def test_sort_desc(self, client, seed_data, field):
         resp = client.get("/api/products", params={"sort_by": field, "sort_dir": "desc"})
@@ -59,7 +59,7 @@ class TestPaginationAndSorting:
         assert values == sorted(values, reverse=True)
 
     def test_invalid_sort_by_rejected(self, client, seed_data):
-        resp = client.get("/api/products", params={"sort_by": "supplier_name"})
+        resp = client.get("/api/products", params={"sort_by": "created_at"})
         assert resp.status_code == 400
 
     def test_invalid_sort_dir_rejected(self, client, seed_data):

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -10,29 +10,30 @@ class TestListProducts:
         resp = client.get("/api/products")
         assert resp.status_code == 200
         data = resp.json()
-        assert isinstance(data, list)
-        assert len(data) == 5
+        assert isinstance(data["items"], list)
+        assert data["total"] == 5
+        assert len(data["items"]) == 5
 
     def test_search_filters_by_name(self, client, seed_data):
         resp = client.get("/api/products", params={"search": "Laptop"})
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["name"] == "Laptop Pro 15"
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "Laptop Pro 15"
 
     def test_search_filters_by_sku(self, client, seed_data):
         resp = client.get("/api/products", params={"search": "NK-001"})
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["sku"] == "NK-001"
+        assert data["total"] == 1
+        assert data["items"][0]["sku"] == "NK-001"
 
     def test_filter_by_category(self, client, seed_data):
         resp = client.get("/api/products", params={"category": "Elektronik"})
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 1
-        assert data[0]["category"] == "Elektronik"
+        assert data["total"] == 1
+        assert data["items"][0]["category"] == "Elektronik"
 
     def test_filter_low_stock(self, client, seed_data):
         """Products where current_stock <= reorder_level should be returned."""
@@ -43,8 +44,8 @@ class TestListProducts:
         # Schreibtischstuhl: stock=5, reorder=10 -> low stock
         # USB-Maus: stock=10, reorder=20 -> low stock
         # Druckerpapier: stock=5, reorder=100 -> low stock
-        assert len(data) >= 3
-        for item in data:
+        assert data["total"] >= 3
+        for item in data["items"]:
             assert item["current_stock"] <= item["reorder_level"]
 
 

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -3,6 +3,79 @@
 import pytest
 
 
+class TestPaginationAndSorting:
+    """GET /api/products — pagination and sort behaviour."""
+
+    def test_default_pagination_metadata(self, client, seed_data):
+        resp = client.get("/api/products")
+        data = resp.json()
+        assert data["limit"] == 25
+        assert data["offset"] == 0
+        assert data["total"] == 5
+
+    def test_limit_caps_items_returned(self, client, seed_data):
+        resp = client.get("/api/products", params={"limit": 2})
+        data = resp.json()
+        assert len(data["items"]) == 2
+        assert data["total"] == 5  # total ignores limit
+
+    def test_offset_skips_items(self, client, seed_data):
+        first = client.get("/api/products", params={"limit": 2, "offset": 0}).json()
+        second = client.get("/api/products", params={"limit": 2, "offset": 2}).json()
+        first_skus = [p["sku"] for p in first["items"]]
+        second_skus = [p["sku"] for p in second["items"]]
+        assert set(first_skus).isdisjoint(second_skus)
+
+    def test_limit_below_minimum_rejected(self, client, seed_data):
+        resp = client.get("/api/products", params={"limit": 0})
+        assert resp.status_code == 422
+
+    def test_limit_above_maximum_rejected(self, client, seed_data):
+        resp = client.get("/api/products", params={"limit": 101})
+        assert resp.status_code == 422
+
+    def test_negative_offset_rejected(self, client, seed_data):
+        resp = client.get("/api/products", params={"offset": -1})
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "field",
+        ["name", "sku", "category", "unit_price", "current_stock"],
+    )
+    def test_sort_asc(self, client, seed_data, field):
+        resp = client.get("/api/products", params={"sort_by": field, "sort_dir": "asc"})
+        items = resp.json()["items"]
+        values = [item[field] for item in items]
+        assert values == sorted(values)
+
+    @pytest.mark.parametrize(
+        "field",
+        ["name", "sku", "category", "unit_price", "current_stock"],
+    )
+    def test_sort_desc(self, client, seed_data, field):
+        resp = client.get("/api/products", params={"sort_by": field, "sort_dir": "desc"})
+        items = resp.json()["items"]
+        values = [item[field] for item in items]
+        assert values == sorted(values, reverse=True)
+
+    def test_invalid_sort_by_rejected(self, client, seed_data):
+        resp = client.get("/api/products", params={"sort_by": "supplier_name"})
+        assert resp.status_code == 400
+
+    def test_invalid_sort_dir_rejected(self, client, seed_data):
+        resp = client.get("/api/products", params={"sort_dir": "sideways"})
+        assert resp.status_code == 400
+
+    def test_filters_combine_with_pagination(self, client, seed_data):
+        resp = client.get(
+            "/api/products",
+            params={"category": "Elektronik", "limit": 10},
+        )
+        data = resp.json()
+        assert data["total"] == 1  # only one Elektronik product in seed
+        assert all(item["category"] == "Elektronik" for item in data["items"])
+
+
 class TestListProducts:
     """GET /api/products"""
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,9 @@
 import type {
   Product,
   ProductCreate,
+  PaginatedProducts,
+  ProductSortField,
+  SortDirection,
   Movement,
   MovementCreate,
   Supplier,
@@ -67,13 +70,21 @@ export function fetchProducts(params?: {
   search?: string;
   category?: string;
   low_stock?: boolean;
-}): Promise<Product[]> {
+  sort_by?: ProductSortField;
+  sort_dir?: SortDirection;
+  limit?: number;
+  offset?: number;
+}): Promise<PaginatedProducts> {
   const query = new URLSearchParams();
   if (params?.search) query.set("search", params.search);
   if (params?.category) query.set("category", params.category);
   if (params?.low_stock) query.set("low_stock", "true");
+  if (params?.sort_by) query.set("sort_by", params.sort_by);
+  if (params?.sort_dir) query.set("sort_dir", params.sort_dir);
+  if (params?.limit !== undefined) query.set("limit", String(params.limit));
+  if (params?.offset !== undefined) query.set("offset", String(params.offset));
   const qs = query.toString();
-  return get<Product[]>(`/api/products${qs ? `?${qs}` : ""}`);
+  return get<PaginatedProducts>(`/api/products${qs ? `?${qs}` : ""}`);
 }
 
 export function fetchProduct(id: number): Promise<Product> {

--- a/frontend/src/pages/Movements.tsx
+++ b/frontend/src/pages/Movements.tsx
@@ -62,7 +62,9 @@ export default function Movements() {
   }, [loadMovements]);
 
   useEffect(() => {
-    fetchProducts().then(setProducts).catch(() => {});
+    fetchProducts({ limit: 100 })
+      .then((data) => setProducts(data.items))
+      .catch(() => {});
   }, []);
 
   async function handleSave(e: React.FormEvent) {

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState, useCallback, useRef } from "react";
-import { Pencil, Trash2, Plus, Search, Upload, Download } from "lucide-react";
+import {
+  Pencil,
+  Trash2,
+  Plus,
+  Search,
+  Upload,
+  Download,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+} from "lucide-react";
 import {
   fetchProducts,
   fetchSuppliers,
@@ -9,7 +19,13 @@ import {
   importProductsCsv,
   exportProductsCsv,
 } from "../api/client";
-import type { Product, ProductCreate, Supplier } from "../types";
+import type {
+  Product,
+  ProductCreate,
+  Supplier,
+  ProductSortField,
+  SortDirection,
+} from "../types";
 import Modal from "../components/Modal";
 import LoadingSpinner from "../components/LoadingSpinner";
 
@@ -30,8 +46,11 @@ const emptyForm: ProductCreate = {
   reorder_level: 0,
 };
 
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
 export default function Products() {
   const [products, setProducts] = useState<Product[]>([]);
+  const [total, setTotal] = useState(0);
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -39,6 +58,11 @@ export default function Products() {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [lowStockOnly, setLowStockOnly] = useState(false);
+
+  const [sortBy, setSortBy] = useState<ProductSortField>("name");
+  const [sortDir, setSortDir] = useState<SortDirection>("asc");
+  const [limit, setLimit] = useState(25);
+  const [offset, setOffset] = useState(0);
 
   const [modalOpen, setModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -65,11 +89,44 @@ export default function Products() {
       search: search || undefined,
       category: categoryFilter || undefined,
       low_stock: lowStockOnly || undefined,
+      sort_by: sortBy,
+      sort_dir: sortDir,
+      limit,
+      offset,
     })
-      .then(setProducts)
+      .then((data) => {
+        setProducts(data.items);
+        setTotal(data.total);
+      })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
-  }, [search, categoryFilter, lowStockOnly]);
+  }, [search, categoryFilter, lowStockOnly, sortBy, sortDir, limit, offset]);
+
+  // Reset to the first page whenever filters or page size change
+  useEffect(() => {
+    setOffset(0);
+  }, [search, categoryFilter, lowStockOnly, limit]);
+
+  function toggleSort(field: ProductSortField) {
+    if (sortBy === field) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortBy(field);
+      setSortDir("asc");
+    }
+    setOffset(0);
+  }
+
+  function SortIcon({ field }: { field: ProductSortField }) {
+    if (sortBy !== field) {
+      return <ChevronsUpDown className="w-3 h-3 inline-block ml-1 text-gray-400" />;
+    }
+    return sortDir === "asc" ? (
+      <ChevronUp className="w-3 h-3 inline-block ml-1 text-blue-600" />
+    ) : (
+      <ChevronDown className="w-3 h-3 inline-block ml-1 text-blue-600" />
+    );
+  }
 
   useEffect(() => {
     loadProducts();
@@ -251,12 +308,42 @@ export default function Products() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b bg-gray-50 text-left text-gray-500">
-                <th className="px-4 py-3 font-medium">SKU</th>
-                <th className="px-4 py-3 font-medium">Name</th>
-                <th className="px-4 py-3 font-medium">Category</th>
+                <th
+                  onClick={() => toggleSort("sku")}
+                  className="px-4 py-3 font-medium cursor-pointer select-none hover:text-gray-700"
+                >
+                  SKU
+                  <SortIcon field="sku" />
+                </th>
+                <th
+                  onClick={() => toggleSort("name")}
+                  className="px-4 py-3 font-medium cursor-pointer select-none hover:text-gray-700"
+                >
+                  Name
+                  <SortIcon field="name" />
+                </th>
+                <th
+                  onClick={() => toggleSort("category")}
+                  className="px-4 py-3 font-medium cursor-pointer select-none hover:text-gray-700"
+                >
+                  Category
+                  <SortIcon field="category" />
+                </th>
                 <th className="px-4 py-3 font-medium">Supplier</th>
-                <th className="px-4 py-3 font-medium text-right">Price</th>
-                <th className="px-4 py-3 font-medium text-right">Stock</th>
+                <th
+                  onClick={() => toggleSort("unit_price")}
+                  className="px-4 py-3 font-medium text-right cursor-pointer select-none hover:text-gray-700"
+                >
+                  Price
+                  <SortIcon field="unit_price" />
+                </th>
+                <th
+                  onClick={() => toggleSort("current_stock")}
+                  className="px-4 py-3 font-medium text-right cursor-pointer select-none hover:text-gray-700"
+                >
+                  Stock
+                  <SortIcon field="current_stock" />
+                </th>
                 <th className="px-4 py-3 font-medium text-right">Reorder Level</th>
                 <th className="px-4 py-3 font-medium">Actions</th>
               </tr>
@@ -313,6 +400,47 @@ export default function Products() {
               )}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {!loading && total > 0 && (
+        <div className="flex items-center justify-between mt-4 text-sm text-gray-600">
+          <div className="flex items-center gap-3">
+            <span>
+              Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}
+            </span>
+            <select
+              value={limit}
+              onChange={(e) => setLimit(Number(e.target.value))}
+              className="border rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Page size"
+            >
+              {PAGE_SIZE_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt} / page
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+              disabled={offset === 0}
+              className="px-3 py-1 border rounded-lg hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Prev
+            </button>
+            <span>
+              Page {Math.floor(offset / limit) + 1} of {Math.max(1, Math.ceil(total / limit))}
+            </span>
+            <button
+              onClick={() => setOffset(offset + limit)}
+              disabled={offset + limit >= total}
+              className="px-3 py-1 border rounded-lg hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Next
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -329,7 +329,13 @@ export default function Products() {
                   Category
                   <SortIcon field="category" />
                 </th>
-                <th className="px-4 py-3 font-medium">Supplier</th>
+                <th
+                  onClick={() => toggleSort("supplier_name")}
+                  className="px-4 py-3 font-medium cursor-pointer select-none hover:text-gray-700"
+                >
+                  Supplier
+                  <SortIcon field="supplier_name" />
+                </th>
                 <th
                   onClick={() => toggleSort("unit_price")}
                   className="px-4 py-3 font-medium text-right cursor-pointer select-none hover:text-gray-700"
@@ -344,7 +350,13 @@ export default function Products() {
                   Stock
                   <SortIcon field="current_stock" />
                 </th>
-                <th className="px-4 py-3 font-medium text-right">Reorder Level</th>
+                <th
+                  onClick={() => toggleSort("reorder_level")}
+                  className="px-4 py-3 font-medium text-right cursor-pointer select-none hover:text-gray-700"
+                >
+                  Reorder Level
+                  <SortIcon field="reorder_level" />
+                </th>
                 <th className="px-4 py-3 font-medium">Actions</th>
               </tr>
             </thead>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -32,8 +32,10 @@ export type ProductSortField =
   | "name"
   | "sku"
   | "category"
+  | "supplier_name"
   | "unit_price"
-  | "current_stock";
+  | "current_stock"
+  | "reorder_level";
 
 export type SortDirection = "asc" | "desc";
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -21,6 +21,22 @@ export interface ProductCreate {
   reorder_level: number;
 }
 
+export interface PaginatedProducts {
+  items: Product[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export type ProductSortField =
+  | "name"
+  | "sku"
+  | "category"
+  | "unit_price"
+  | "current_stock";
+
+export type SortDirection = "asc" | "desc";
+
 export interface Movement {
   id: number;
   product_id: number;


### PR DESCRIPTION
## Summary

- `GET /api/products` now accepts `limit` (default 25, max 100), `offset`, `sort_by` (name / sku / category / unit_price / current_stock), and `sort_dir` (asc / desc)
- Response shape changed to `{ items, total, limit, offset }`
- Frontend Products page has clickable column headers (with chevron indicators), Prev/Next pagination controls, and a page-size selector
- 19 new backend tests covering bounds checking, sorting in both directions for all sortable fields, and filter-combined pagination

Closes #23

## Breaking change

The response shape for `GET /api/products` changed from `Product[]` to `{ items: Product[], total, limit, offset }`. All existing tests and the frontend have been updated to match.

## Test plan

- [x] All 91 backend tests pass (`pytest -v`)
- [x] All 8 frontend tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual: click a column header, table re-sorts; click again, direction flips
- [ ] Manual: set page size to 10, navigate with Prev/Next
- [ ] Manual: apply a search filter, pagination resets to page 1
