### PR TITLE
Replace alert() with toast notifications

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "lucide-react": "^0.468.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.1.0",
         "recharts": "^2.15.0"
       },
@@ -3662,6 +3663,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4636,6 +4646,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "lucide-react": "^0.468.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.1.0",
     "recharts": "^2.15.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { Toaster } from "react-hot-toast";
 import { AuthProvider } from "./context/AuthContext";
 import PrivateRoute from "./components/PrivateRoute";
 import Layout from "./components/Layout";
@@ -12,6 +13,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
+        <Toaster position="top-right" toastOptions={{ duration: 3000 }} />
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route element={<PrivateRoute />}>

--- a/frontend/src/pages/Movements.tsx
+++ b/frontend/src/pages/Movements.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { Plus } from "lucide-react";
+import toast from "react-hot-toast";
 import {
   fetchMovements,
   fetchProducts,
@@ -72,11 +73,12 @@ export default function Movements() {
     setSaving(true);
     try {
       await createMovement(form);
+      toast.success("Movement recorded");
       setModalOpen(false);
       setForm(emptyForm);
       loadMovements();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to record movement");
+      toast.error(err instanceof Error ? err.message : "Failed to record movement");
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronsUpDown,
 } from "lucide-react";
+import toast from "react-hot-toast";
 import {
   fetchProducts,
   fetchSuppliers,
@@ -163,13 +164,15 @@ export default function Products() {
     try {
       if (editingId) {
         await updateProduct(editingId, form);
+        toast.success("Product updated");
       } else {
         await createProduct(form);
+        toast.success("Product created");
       }
       setModalOpen(false);
       loadProducts();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to save product");
+      toast.error(err instanceof Error ? err.message : "Failed to save product");
     } finally {
       setSaving(false);
     }
@@ -180,10 +183,11 @@ export default function Products() {
     setDeleting(true);
     try {
       await deleteProduct(deleteId);
+      toast.success("Product deleted");
       setDeleteId(null);
       loadProducts();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete product");
+      toast.error(err instanceof Error ? err.message : "Failed to delete product");
     } finally {
       setDeleting(false);
     }
@@ -206,7 +210,7 @@ export default function Products() {
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Export failed");
+      toast.error(err instanceof Error ? err.message : "Export failed");
     } finally {
       setExporting(false);
     }
@@ -220,9 +224,15 @@ export default function Products() {
     try {
       const result = await importProductsCsv(file);
       setImportResult(result);
+      if (result.imported > 0) {
+        toast.success(`Imported ${result.imported} product(s)`);
+      }
+      if (result.skipped > 0) {
+        toast.error(`Skipped ${result.skipped} row(s) — see details in the dialog`);
+      }
       loadProducts();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Import failed");
+      toast.error(err instanceof Error ? err.message : "Import failed");
     } finally {
       setImporting(false);
     }

--- a/frontend/src/pages/Suppliers.tsx
+++ b/frontend/src/pages/Suppliers.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { Pencil, Trash2, Plus, Search } from "lucide-react";
+import toast from "react-hot-toast";
 import {
   fetchSuppliers,
   createSupplier,
@@ -72,13 +73,15 @@ export default function Suppliers() {
     try {
       if (editingId) {
         await updateSupplier(editingId, form);
+        toast.success("Supplier updated");
       } else {
         await createSupplier(form);
+        toast.success("Supplier created");
       }
       setModalOpen(false);
       loadSuppliers();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to save supplier");
+      toast.error(err instanceof Error ? err.message : "Failed to save supplier");
     } finally {
       setSaving(false);
     }
@@ -90,6 +93,7 @@ export default function Suppliers() {
     setDeleteError("");
     try {
       await deleteSupplier(deleteId);
+      toast.success("Supplier deleted");
       setDeleteId(null);
       loadSuppliers();
     } catch (err) {


### PR DESCRIPTION
## Summary

- New dependency: `react-hot-toast` (~5 kB)
- `<Toaster />` mounted once in `App.tsx`, top-right, 3-second duration
- All 6 `alert(...)` calls replaced with `toast.error(...)` across Products, Movements, and Suppliers pages
- `toast.success(...)` added on every successful create / update / delete / import operation
- Suppliers delete error keeps its inline modal message (better UX than a transient toast for the "linked products" hint)

Closes #24

## Test plan

- [x] No remaining `alert()` calls in `frontend/src` (verified by grep)
- [x] Frontend build succeeds
- [x] All 8 frontend tests still pass
- [x] All 95 backend tests still pass
- [ ] Manual: create a product → green success toast appears
- [ ] Manual: delete a product with stock > 0 → red error toast with the backend error message
- [ ] Manual: import a CSV with a duplicate SKU → success toast for imported rows, error toast for skipped rows
