### PR TITLE
Report test coverage in CI (backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,18 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r backend/requirements.txt
+          pip install -r backend/requirements.txt -r backend/requirements-dev.txt
 
-      - name: Run tests
+      - name: Run tests with coverage
         working-directory: backend
-        run: pytest -v
+        run: pytest -v --cov=agents --cov=db --cov=models --cov-report=term-missing --cov-report=xml --cov-fail-under=85
+
+      - name: Coverage summary
+        if: always() && matrix.python-version == '3.12'
+        working-directory: backend
+        run: |
+          echo "### Coverage" >> "$GITHUB_STEP_SUMMARY"
+          python -c "import xml.etree.ElementTree as ET; print(f\"Line coverage: {float(ET.parse('coverage.xml').getroot().get('line-rate'))*100:.1f}%\")" >> "$GITHUB_STEP_SUMMARY"
 
   frontend:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ backend/db/*.db
 # Frontend
 frontend/node_modules/
 frontend/dist/
+
+# Coverage
+.coverage
+coverage.xml
+htmlcov/

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,1 +1,2 @@
 ruff>=0.15
+pytest-cov>=5


### PR DESCRIPTION
Measures test coverage on the matrix and enforces a floor.

What changed:
- pytest-cov added to requirements-dev.txt
- the test job runs pytest with coverage and fails below the threshold
- line coverage is written to the CI job summary
- coverage output files are git ignored

I used a CI threshold plus a job summary rather than a Codecov badge, so no external account is needed. A dynamic badge can be added later by connecting Codecov.

Closes #31