### PR TITLE
Ignore runtime SQLite database files in backend/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ frontend/dist/
 .coverage
 coverage.xml
 htmlcov/
+
+backend/*.db


### PR DESCRIPTION
The FastAPI app writes backend/inventory.db at runtime. The existing rule only covers backend/db/*.db, so the file showed up as untracked. Adds backend/*.db.

Closes #34