### PR TITLE
Upgrade frontend to TypeScript 6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.0.0",
-        "typescript": "~5.7.0",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.2",
         "vite": "^6.0.0",
         "vitest": "^4.1.5"
@@ -5166,9 +5166,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.0.0",
-    "typescript": "~5.7.0",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^6.0.0",
     "vitest": "^4.1.5"


### PR DESCRIPTION
Bumps TypeScript to ~6.0.3. React is already on 19, so this is the remaining frontend major.

Verified locally: tsc -b reports no type errors, vite build succeeds, and all 8 frontend tests pass. No source changes were needed.

Closes #32