### PR TITLE
Add docker-compose stack for the backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,28 @@ jobs:
       - name: Build
         working-directory: frontend
         run: npm run build
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build and start the stack
+        run: docker compose up -d --build
+
+      - name: Wait for the API through the frontend proxy
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS http://localhost:8080/api/health >/dev/null; then echo "stack is up"; exit 0; fi
+            sleep 3
+          done
+          echo "stack did not become healthy"
+          docker compose logs
+          exit 1
+
+      - name: Check the frontend serves the app
+        run: curl -fsS http://localhost:8080/ | grep -qi "<!doctype html"
+
+      - name: Tear down
+        if: always()
+        run: docker compose down

--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ Full-stack inventory management system with a React/TypeScript frontend and Fast
 ### With Docker
 
 ```bash
-docker build -t inventory-management .
-docker run -p 8000:8000 inventory-management
+docker compose up
 ```
 
-Open http://localhost:8000 in your browser.
+This builds and starts the FastAPI backend and the React frontend. Open
+http://localhost:8080 in your browser. The frontend serves the app and
+proxies API calls to the backend, which keeps its SQLite database in a
+named volume.
 
 ### Manual Setup
 

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.db
+venv/
+.venv/
+.git/
+tests/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -4,7 +4,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DATABASE_URL = f"sqlite:///{os.path.join(BASE_DIR, 'inventory.db')}"
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", f"sqlite:///{os.path.join(BASE_DIR, 'inventory.db')}"
+)
 
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 

--- a/backend/db/database.py
+++ b/backend/db/database.py
@@ -4,9 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", f"sqlite:///{os.path.join(BASE_DIR, 'inventory.db')}"
-)
+DATABASE_URL = os.getenv("DATABASE_URL", f"sqlite:///{os.path.join(BASE_DIR, 'inventory.db')}")
 
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: sqlite:////data/inventory.db
+    volumes:
+      - inventory-data:/data
+    expose:
+      - "8000"
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "8080:80"
+
+volumes:
+  inventory-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.git/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
Containers for the full stack, started with docker compose up.

What changed:
- Dockerfile for the FastAPI backend
- multi-stage Dockerfile for the React frontend, served by nginx
- nginx serves the built app and proxies /api to the backend
- docker-compose.yml wiring both, backend keeps its SQLite database in a named volume (DATABASE_URL, local default unchanged)
- README updated from the outdated single-image command to docker compose up, so the Docker badge is now accurate
- a CI job that builds the stack, starts it, and smoke tests the API through the frontend proxy

Closes #33